### PR TITLE
Using defaults instead, can be overridden at group vars level

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+java_version: "7"
+java_register_alternative: false
+java_register_env: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,4 @@
 ---
 java_playbook_version: "0.1.4" # playbook version
-java_version: "7"
 java_libjvm_path: "/usr/lib/jvm/java-{{java_version}}-*/jre/lib/*/server/libjvm.so"
 java_libjvm_symlink_path: "/usr/lib/libjvm.so"
-java_register_alternative: false
-java_register_env: false


### PR DESCRIPTION
Role variables were too high in [precedence](http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) level they couldn't be overridden in group variables. Overriding them at role level (e.g. `{ role: ansible-java, java_version: 8 }`) is not always desired as it forces sometimes to define another set of variables to control it (i.e. `{ role: ansible-java, java_version: "{{ my_other_java_version }}" }`)
